### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/196/557/421196557.geojson
+++ b/data/421/196/557/421196557.geojson
@@ -552,6 +552,9 @@
     },
     "wof:country":"TL",
     "wof:created":1459009885,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"979866fc641a48c466861207fc87fa2a",
     "wof:hierarchy":[
         {
@@ -562,7 +565,7 @@
         }
     ],
     "wof:id":421196557,
-    "wof:lastmodified":1566666873,
+    "wof:lastmodified":1582331162,
     "wof:name":"Dili",
     "wof:parent_id":85678943,
     "wof:placetype":"locality",

--- a/data/856/325/83/85632583.geojson
+++ b/data/856/325/83/85632583.geojson
@@ -1001,6 +1001,10 @@
     },
     "wof:country":"TL",
     "wof:country_alpha3":"TLS",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"0461b525cf17c49d4bd336e3fd8f5479",
     "wof:hierarchy":[
         {
@@ -1017,7 +1021,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1566666680,
+    "wof:lastmodified":1582331159,
     "wof:name":"East Timor",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.