### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/421/181/781/421181781.geojson
+++ b/data/421/181/781/421181781.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u062f\u064a\u0629 \u0628\u0648\u0643\u0627\u0648"
     ],
+    "name:aze_x_preferred":[
+        "Baukau b\u0259l\u0259diyy\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u0989\u0995\u09be\u0989 \u09aa\u09cc\u09b0\u09b8\u09ad\u09be"
     ],
@@ -32,6 +35,9 @@
     "name:ceb_x_preferred":[
         "Baucau"
     ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Baucau"
+    ],
     "name:dan_x_preferred":[
         "Baucau Municipality"
     ],
@@ -43,6 +49,9 @@
     ],
     "name:eng_x_preferred":[
         "Baucau Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0628\u0627\u0648\u06a9\u0648"
     ],
     "name:fin_x_preferred":[
         "Baucaun alue"
@@ -77,6 +86,9 @@
     "name:kor_x_preferred":[
         "\ubc14\uc6b0\uce74\uc6b0 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ubc14\uc6b0\uce74\uc6b0\ud604"
+    ],
     "name:lav_x_preferred":[
         "Baukau pa\u0161vald\u012bba"
     ],
@@ -86,8 +98,14 @@
     "name:mar_x_preferred":[
         "\u092c\u0915\u093e\u0909 \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0443\u043a\u0430\u0443"
+    ],
     "name:msa_x_preferred":[
         "Baucau Municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Baucau Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Baucau"
@@ -109,6 +127,9 @@
     ],
     "name:swe_x_preferred":[
         "Baucau"
+    ],
+    "name:tam_x_preferred":[
+        "\u0baa\u0bbe\u0b95\u0bcd\u0b95\u0bc1\u0b95\u0bbe \u0ba8\u0b95\u0bb0\u0bbe\u0b9f\u0bcd\u0b9a\u0bbf"
     ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c15\u0c3e\u0c35\u0c41 \u0c2e\u0c41\u0c28\u0c4d\u0c38\u0c3f\u0c2a\u0c3e\u0c32\u0c3f\u0c1f\u0c40"
@@ -180,7 +201,7 @@
         }
     ],
     "wof:id":421181781,
-    "wof:lastmodified":1566666873,
+    "wof:lastmodified":1690874635,
     "wof:name":"Baukau",
     "wof:parent_id":85678967,
     "wof:placetype":"locality",

--- a/data/421/191/529/421191529.geojson
+++ b/data/421/191/529/421191529.geojson
@@ -20,6 +20,15 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0643\u0627\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0643\u0627\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Baucau"
+    ],
+    "name:aze_x_preferred":[
+        "Baykay"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09c1\u0995\u09be\u0989"
     ],
@@ -206,7 +215,7 @@
         }
     ],
     "wof:id":421191529,
-    "wof:lastmodified":1566666873,
+    "wof:lastmodified":1690874636,
     "wof:name":"Vila Salazar",
     "wof:parent_id":85678967,
     "wof:placetype":"locality",

--- a/data/421/195/531/421195531.geojson
+++ b/data/421/195/531/421195531.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0646\u0627\u062a\u0648\u062a\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0646\u0627\u062a\u0648\u062a\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Manatuto"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09a8\u09be\u099f\u09be\u099f\u09c1"
+    ],
+    "name:cat_x_preferred":[
+        "Manatuto"
     ],
     "name:ceb_x_preferred":[
         "Manatuto"
@@ -187,7 +196,7 @@
         }
     ],
     "wof:id":421195531,
-    "wof:lastmodified":1636497446,
+    "wof:lastmodified":1690874635,
     "wof:name":"Manatuto",
     "wof:parent_id":85678985,
     "wof:placetype":"locality",

--- a/data/421/196/557/421196557.geojson
+++ b/data/421/196/557/421196557.geojson
@@ -31,11 +31,23 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0644\u064a"
     ],
+    "name:ary_x_preferred":[
+        "\u062f\u064a\u0644\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0644\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Dili"
+    ],
     "name:aze_x_preferred":[
         "Dili"
     ],
     "name:bak_x_preferred":[
         "\u0414\u0438\u043b\u0438"
+    ],
+    "name:ban_x_preferred":[
+        "Dili"
     ],
     "name:bar_x_preferred":[
         "Dili"
@@ -133,6 +145,9 @@
     "name:gla_x_preferred":[
         "Dili"
     ],
+    "name:gle_x_preferred":[
+        "Dili"
+    ],
     "name:glg_x_preferred":[
         "Dili"
     ],
@@ -184,6 +199,9 @@
     "name:ita_x_preferred":[
         "Dili"
     ],
+    "name:jav_x_preferred":[
+        "Dili"
+    ],
     "name:jpn_x_preferred":[
         "\u30c7\u30a3\u30ea"
     ],
@@ -199,6 +217,9 @@
     "name:kaz_x_preferred":[
         "\u0414\u0438\u043b\u0438"
     ],
+    "name:khm_x_preferred":[
+        "\u178c\u17b8\u179b\u17b8"
+    ],
     "name:kir_x_preferred":[
         "\u0414\u0438\u043b\u0438"
     ],
@@ -208,6 +229,9 @@
     "name:lad_x_preferred":[
         "Dili"
     ],
+    "name:lao_x_preferred":[
+        "\u0e94\u0eb4\u0ea5\u0eb5"
+    ],
     "name:lat_x_preferred":[
         "Dili"
     ],
@@ -215,6 +239,9 @@
         "Dilium"
     ],
     "name:lav_x_preferred":[
+        "Dili"
+    ],
+    "name:lfn_x_preferred":[
         "Dili"
     ],
     "name:lij_x_preferred":[
@@ -252,6 +279,12 @@
     ],
     "name:mya_x_preferred":[
         "\u1012\u102e\u101c\u102e\u1019\u103c\u102d\u102f\u1037"
+    ],
+    "name:mzn_x_preferred":[
+        "\u062f\u06cc\u0644\u06cc"
+    ],
+    "name:nah_x_preferred":[
+        "Dili"
     ],
     "name:nan_x_preferred":[
         "Dili"
@@ -313,6 +346,9 @@
     "name:rus_x_preferred":[
         "\u0414\u0438\u043b\u0438"
     ],
+    "name:sat_x_preferred":[
+        "\u1c70\u1c64\u1c5e\u1c64"
+    ],
     "name:scn_x_preferred":[
         "Dili"
     ],
@@ -331,6 +367,9 @@
     "name:sna_x_preferred":[
         "Dili"
     ],
+    "name:snd_x_preferred":[
+        "\u062f\u0644\u064a"
+    ],
     "name:spa_x_preferred":[
         "Dili"
     ],
@@ -343,6 +382,9 @@
     "name:srp_x_preferred":[
         "\u0414\u0438\u043b\u0438"
     ],
+    "name:sun_x_preferred":[
+        "Dili"
+    ],
     "name:swa_x_preferred":[
         "Dili"
     ],
@@ -351,6 +393,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9f\u0bbf\u0bb2\u0bbf"
+    ],
+    "name:tat_x_preferred":[
+        "\u0414\u0438\u043b\u0438"
     ],
     "name:tel_x_preferred":[
         "\u0c26\u0c3f\u0c32\u0c3f"
@@ -367,8 +412,14 @@
     "name:tha_x_preferred":[
         "\u0e14\u0e34\u0e25\u0e35"
     ],
+    "name:tpi_x_preferred":[
+        "Dili"
+    ],
     "name:tur_x_preferred":[
         "Dili"
+    ],
+    "name:udm_x_preferred":[
+        "\u0414\u0438\u043b\u0438"
     ],
     "name:uig_x_preferred":[
         "\u062f\u0649\u0644\u0649"
@@ -383,6 +434,9 @@
         "\u062f\u06cc\u0644\u06cc"
     ],
     "name:uzb_x_preferred":[
+        "Dili"
+    ],
+    "name:vec_x_preferred":[
         "Dili"
     ],
     "name:vep_x_preferred":[
@@ -567,7 +621,7 @@
         }
     ],
     "wof:id":421196557,
-    "wof:lastmodified":1607390887,
+    "wof:lastmodified":1690874636,
     "wof:name":"Dili",
     "wof:parent_id":85678943,
     "wof:placetype":"locality",

--- a/data/421/199/889/421199889.geojson
+++ b/data/421/199/889/421199889.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0633\u064a\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u064a\u0645"
+    ],
+    "name:ast_x_preferred":[
+        "Same"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u0987\u09ae"
     ],
@@ -191,7 +197,7 @@
         }
     ],
     "wof:id":421199889,
-    "wof:lastmodified":1636497446,
+    "wof:lastmodified":1690874636,
     "wof:name":"Same",
     "wof:parent_id":85678989,
     "wof:placetype":"locality",

--- a/data/421/200/025/421200025.geojson
+++ b/data/421/200/025/421200025.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0644\u064a\u0627\u0646\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0644\u064a\u0627\u0646\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Maliana"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b2\u09bf\u09af\u09bc\u09be\u09a8\u09be"
     ],
@@ -178,7 +184,7 @@
         }
     ],
     "wof:id":421200025,
-    "wof:lastmodified":1566666873,
+    "wof:lastmodified":1690874636,
     "wof:name":"Maliana",
     "wof:parent_id":85678971,
     "wof:placetype":"locality",

--- a/data/421/200/139/421200139.geojson
+++ b/data/421/200/139/421200139.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0646\u062a \u0645\u0627\u0643\u0627\u0633\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0646\u062a \u0645\u0627\u0643\u0627\u0633\u0627\u0631"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09be\u09a8\u09cd\u09a4\u09c7 \u09ae\u09cd\u09af\u09be\u0995\u09be\u09b8\u09be\u09b0"
     ],
@@ -47,8 +50,14 @@
     "name:guj_x_preferred":[
         "\u0aaa\u0ac7\u0aa8\u0acd\u0a9f\u0ac7 \u0aae\u0ac7\u0a95\u0ab8\u0acd\u0ab8\u0ab0"
     ],
+    "name:heb_x_preferred":[
+        "\u05e4\u05e0\u05d8\u05d4 \u05de\u05e7\u05d0\u05e1\u05d0\u05e8"
+    ],
     "name:hin_x_preferred":[
         "\u092a\u0948\u0902\u091f \u092e\u0915\u093e\u0938\u094d\u0938\u0930"
+    ],
+    "name:hin_x_variant":[
+        "\u092a\u0948\u0902\u091f  \u092e\u0915\u093e\u0938\u094d\u0938\u0930"
     ],
     "name:ind_x_preferred":[
         "Pante Makasar"
@@ -64,6 +73,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud310\ud2b8\ub9c8\uce74\uc0ac\ub974"
+    ],
+    "name:kor_x_variant":[
+        "\ud310\ud14c\ub9c8\uce74\uc0ac\ub974"
     ],
     "name:lav_x_preferred":[
         "Pante Makasara"
@@ -134,6 +146,9 @@
     "name:war_x_preferred":[
         "Pante Macassar"
     ],
+    "name:zho_x_preferred":[
+        "\u4f69\u7279\u00b7\u9ea5\u5361\u745f"
+    ],
     "qs:gn_country":"TL",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":1632533,
@@ -175,7 +190,7 @@
         }
     ],
     "wof:id":421200139,
-    "wof:lastmodified":1566666874,
+    "wof:lastmodified":1690874637,
     "wof:name":"Pante Macassar",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/421/200/961/421200961.geojson
+++ b/data/421/200/961/421200961.geojson
@@ -20,8 +20,14 @@
     "name:ara_x_preferred":[
         "\u0623\u064a\u0646\u0627\u0631\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u064a\u0646\u0627\u0631\u0648"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0439\u043d\u0430\u0440\u0443"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u0439\u043d\u0430\u0440\u0443"
     ],
     "name:ben_x_preferred":[
         "\u0986\u0987\u09a8\u09be\u09b0\u09c1"
@@ -188,7 +194,7 @@
         }
     ],
     "wof:id":421200961,
-    "wof:lastmodified":1636497446,
+    "wof:lastmodified":1690874637,
     "wof:name":"Ainaro",
     "wof:parent_id":85678963,
     "wof:placetype":"locality",

--- a/data/856/325/83/85632583.geojson
+++ b/data/856/325/83/85632583.geojson
@@ -37,6 +37,9 @@
     "name:aka_x_preferred":[
         "Tim\u0254 Boka"
     ],
+    "name:aka_x_variant":[
+        "East Timor"
+    ],
     "name:als_x_preferred":[
         "Osttimor"
     ],
@@ -46,8 +49,14 @@
     "name:amh_x_variant":[
         "\u121d\u1235\u122b\u1245 \u1272\u121e\u122d"
     ],
+    "name:ami_x_preferred":[
+        "Timor-leste"
+    ],
     "name:ang_x_preferred":[
         "\u0112asttimor"
+    ],
+    "name:anp_x_preferred":[
+        "\u092a\u0942\u0930\u094d\u0935\u0940 \u0924\u093f\u092e\u094b\u0930"
     ],
     "name:ara_x_preferred":[
         "\u062a\u064a\u0645\u0648\u0631 \u0627\u0644\u0634\u0631\u0642\u064a\u0629"
@@ -106,6 +115,9 @@
     "name:bho_x_preferred":[
         "\u092a\u0942\u0930\u094d\u092c \u0924\u093f\u092e\u094b\u0930"
     ],
+    "name:bis_x_preferred":[
+        "Is Timor"
+    ],
     "name:bjn_x_preferred":[
         "Timor Lorosa'\u00e9"
     ],
@@ -157,6 +169,12 @@
     "name:che_x_variant":[
         "\u041c\u0430\u043b\u043a\u0445\u0431\u0430\u043b\u0435\u0445\u044c\u0430\u0440\u0430 \u0422\u0438\u043c\u043e\u0440"
     ],
+    "name:chr_x_preferred":[
+        "\u13d8\u13bc\u13b5-\u13b4\u13cd\u13d6"
+    ],
+    "name:chy_x_preferred":[
+        "East Timor"
+    ],
     "name:ckb_x_preferred":[
         "\u062a\u06cc\u0645\u06c6\u0631\u06cc \u0695\u06c6\u0698\u06be\u06d5\u06b5\u0627\u062a"
     ],
@@ -177,6 +195,9 @@
     ],
     "name:cym_x_variant":[
         "Timor-Leste"
+    ],
+    "name:dag_x_preferred":[
+        "Timor Est"
     ],
     "name:dan_x_colloquial":[
         "Osttimor"
@@ -326,6 +347,12 @@
     "name:gom_x_variant":[
         "\u092a\u0942\u0930\u094d\u0935 \u0924\u093f\u092e\u094b\u0930"
     ],
+    "name:gpe_x_preferred":[
+        "Timor-Leste"
+    ],
+    "name:grn_x_preferred":[
+        "Kuarahyres\u1ebd Timor"
+    ],
     "name:gsw_x_preferred":[
         "Osttimor"
     ],
@@ -464,7 +491,8 @@
         "\u0e9b\u0eb0\u0ec0\u0e97\u0e94\u0e95\u0eb5\u0ea1\u0ecd\u0e95\u0eb2\u0ec0\u0ea7\u0eb1\u0e99\u0ead\u0ead\u0e81"
     ],
     "name:lao_x_variant":[
-        "\u0e95\u0eb4\u0ea1\u0ecd\u0e95\u0eb2\u0ec0\u0ea7\u0eb1\u0e99\u0ead\u0ead\u0e81"
+        "\u0e95\u0eb4\u0ea1\u0ecd\u0e95\u0eb2\u0ec0\u0ea7\u0eb1\u0e99\u0ead\u0ead\u0e81",
+        "\u0e9b\u0eb0\u0ec0\u0e97\u0e94\u0e95\u0eb5\u0ea1\u0ecd\u0ec1\u0ea5\u0eb1\u0e94\u0eaa\u0eb0\u0ec0\u0e95"
     ],
     "name:lat_x_preferred":[
         "Timoria Orientalis"
@@ -532,11 +560,26 @@
     "name:mlg_x_preferred":[
         "Timor Atsinanana"
     ],
+    "name:mlg_x_variant":[
+        "Tim\u00f4ro Atsinanana"
+    ],
     "name:mlt_x_preferred":[
         "Timor tal-Lvant"
     ],
+    "name:mlt_x_variant":[
+        "Timor Leste"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc7\uabe4\uabc3\uabe3\uabd4-\uabc2\uabe6\uabc1\uabed\uabc7\uabe6"
+    ],
+    "name:mnw_x_preferred":[
+        "\u1000\u105f\u102d\u1014\u103a\u100d\u102f\u1004\u103a\u101e\u1019\u1039\u1019\u1010\u1012\u1033\u1019\u1036\u1000\u103a\u1000\u101b\u1031\u1007\u103c\u1033 \u1011\u1033\u1019\u101d\u103a\u101c\u1031\u101d\u103a\u101e\u103a\u1010\u1031"
+    ],
     "name:mon_x_preferred":[
         "\u0417\u04af\u04af\u043d \u0422\u0438\u043c\u043e\u0440"
+    ],
+    "name:mri_x_preferred":[
+        "T\u012bmoa-ki-te-R\u0101whiti"
     ],
     "name:msa_x_preferred":[
         "Timor Leste"
@@ -582,6 +625,9 @@
     ],
     "name:new_x_preferred":[
         "\u092a\u0942\u0930\u094d\u0935 \u091f\u093f\u092e\u094b\u0930"
+    ],
+    "name:nia_x_preferred":[
+        "Timor Leste"
     ],
     "name:nld_x_preferred":[
         "Oost-Timor"
@@ -660,6 +706,9 @@
     "name:pus_x_preferred":[
         "\u062e\u062a\u064a\u0681 \u067c\u064a\u0645\u0648\u0631"
     ],
+    "name:pus_x_variant":[
+        "\u062e\u062a\u064a\u0681 \u062a\u064a\u0645\u0648\u0631"
+    ],
     "name:que_x_preferred":[
         "Anti Timur"
     ],
@@ -668,6 +717,9 @@
     ],
     "name:ron_x_preferred":[
         "Timorul de Est"
+    ],
+    "name:rue_x_preferred":[
+        "\u0412\u044b\u0445\u043e\u0434\u043d\u044b\u0439 \u0422\u0456\u043c\u043e\u0440"
     ],
     "name:run_x_preferred":[
         "Timoru y'iburasirazuba"
@@ -681,6 +733,9 @@
     "name:sah_x_preferred":[
         "\u0418\u043b\u0438\u043d \u0422\u0438\u043c\u043e\u0440"
     ],
+    "name:sat_x_preferred":[
+        "\u1c65\u1c5f\u1c62\u1c5f\u1c5d \u1c5b\u1c64\u1c62\u1c73\u1c68"
+    ],
     "name:scn_x_preferred":[
         "Timor Est"
     ],
@@ -689,6 +744,9 @@
     ],
     "name:sgs_x_preferred":[
         "R\u012bt\u016b Timuors"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1010\u102e\u1087\u1019\u1031\u1083\u1038\u1015\u103d\u1010\u103a\u1038\u101d\u107c\u103a\u1038\u1022\u103d\u1075\u103a\u1087"
     ],
     "name:sin_x_preferred":[
         "\u0db1\u0dd0\u0d9c\u0dd9\u0db1\u0dc4\u0dd2\u0dbb \u0da7\u0dd2\u0db8\u0ddd\u0dbb\u0dba"
@@ -702,8 +760,14 @@
     "name:sme_x_preferred":[
         "Nuorta-Timor"
     ],
+    "name:smn_x_preferred":[
+        "Nuortt\u00e2-Timor"
+    ],
     "name:smo_x_preferred":[
         "Sasa\u02bbe Timor"
+    ],
+    "name:sms_x_preferred":[
+        "Nu\u00f5rtt-Timor"
     ],
     "name:sna_x_preferred":[
         "East Timor"
@@ -744,6 +808,9 @@
     "name:sun_x_preferred":[
         "Timor W\u00e9tan"
     ],
+    "name:sun_x_variant":[
+        "Timor L\u00e9st\u00e9"
+    ],
     "name:swa_x_preferred":[
         "Timor ya Mashariki"
     ],
@@ -770,6 +837,9 @@
     ],
     "name:tat_x_preferred":[
         "\u041a\u04e9\u043d\u0447\u044b\u0433\u044b\u0448 \u0422\u0438\u043c\u043e\u0440"
+    ],
+    "name:tay_x_preferred":[
+        "Timor-leste"
     ],
     "name:tel_x_preferred":[
         "\u0c24\u0c42\u0c30\u0c4d\u0c2a\u0c41 \u0c24\u0c48\u0c2e\u0c42\u0c30\u0c4d"
@@ -804,7 +874,13 @@
     "name:ton_x_preferred":[
         "Timoa Hahake"
     ],
+    "name:ton_x_variant":[
+        "T\u012bmoa Hahake"
+    ],
     "name:tpi_x_preferred":[
+        "Timor-Leste"
+    ],
+    "name:trv_x_preferred":[
         "Timor-Leste"
     ],
     "name:tuk_x_preferred":[
@@ -818,6 +894,9 @@
     ],
     "name:udm_x_preferred":[
         "\u0428\u0443\u043d\u0434\u044b \u04dd\u0443\u0436\u0430\u043d \u043f\u0430\u043b \u0422\u0438\u043c\u043e\u0440"
+    ],
+    "name:udm_x_variant":[
+        "\u04f4\u0443\u043a\u043f\u0430\u043b \u0422\u0438\u043c\u043e\u0440"
     ],
     "name:uig_x_preferred":[
         "\u0634\u06d5\u0631\u0642\u0649\u064a \u062a\u0649\u0645\u0648\u0631"
@@ -1141,7 +1220,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1617827450,
+    "wof:lastmodified":1690874630,
     "wof:name":"East Timor",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/789/43/85678943.geojson
+++ b/data/856/789/43/85678943.geojson
@@ -59,6 +59,12 @@
     "name:eng_x_variant":[
         "Dili municipality"
     ],
+    "name:epo_x_preferred":[
+        "Municipo Dilo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u062f\u06cc\u0644\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Dilin alue"
     ],
@@ -101,6 +107,9 @@
     "name:kor_x_preferred":[
         "\ub51c\ub9ac \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ub51c\ub9ac\ud604"
+    ],
     "name:lav_x_preferred":[
         "Dili pa\u0161vald\u012bba"
     ],
@@ -110,8 +119,14 @@
     "name:mar_x_preferred":[
         "\u0921\u093f\u0932\u0940 \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0414\u0438\u043b\u0438"
+    ],
     "name:msa_x_preferred":[
         "Dili municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Dili Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Dili"
@@ -294,7 +309,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497442,
+    "wof:lastmodified":1690874632,
     "wof:name":"Dili",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/51/85678951.geojson
+++ b/data/856/789/51/85678951.geojson
@@ -41,6 +41,9 @@
     "name:ceb_x_preferred":[
         "Liqui\u00e7\u00e1"
     ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Liqui\u00e7\u00e1"
+    ],
     "name:dan_x_preferred":[
         "Liqui\u00e7\u00e1"
     ],
@@ -58,6 +61,9 @@
         "Liqui\u00e7\u00e1 District",
         "Liqui\u00e7\u00e1",
         "Liqui\u00e7\u00e1 Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0644\u06cc\u06a9\u06cc\u0686\u0627"
     ],
     "name:fin_x_preferred":[
         "Liqui\u00e7\u00e1n alue"
@@ -108,7 +114,8 @@
         "\ub9ac\ud0a4\uc0ac \uc8fc"
     ],
     "name:kor_x_variant":[
-        "\ub9ac\ud0a4\uc0ac \ud604"
+        "\ub9ac\ud0a4\uc0ac \ud604",
+        "\ub9ac\ud0a4\uc0ac\ud604"
     ],
     "name:lav_x_preferred":[
         "Likisas pa\u0161vald\u012bba"
@@ -119,8 +126,14 @@
     "name:mar_x_preferred":[
         "\u0932\u093f\u0915\u094d\u0935\u093f\u092f\u093e \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u041b\u0438\u043a\u0438\u0441\u0430"
+    ],
     "name:msa_x_preferred":[
         "Liquica Municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Liqui\u00e7\u00e1 Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Liqui\u00e7\u00e1"
@@ -306,7 +319,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497441,
+    "wof:lastmodified":1690874631,
     "wof:name":"Liquica",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/53/85678953.geojson
+++ b/data/856/789/53/85678953.geojson
@@ -75,6 +75,9 @@
     "name:eus_x_preferred":[
         "Oecusse Barrutia"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0648\u06a9\u0648\u0633"
+    ],
     "name:fin_x_preferred":[
         "Oecussen alue"
     ],
@@ -83,6 +86,9 @@
     ],
     "name:fra_x_variant":[
         "Oe-Cusse Ambeno"
+    ],
+    "name:frr_x_preferred":[
+        "Oecusse"
     ],
     "name:guj_x_preferred":[
         "\u0a93\u0ab8\u0a95\u0acd\u0aaf\u0ac1\u0ab8 \u0aae\u0acd\u0aaf\u0ac1\u0aa8\u0abf\u0ab8\u0abf\u0aaa\u0abe\u0ab2\u0abf\u0a9f\u0ac0"
@@ -117,6 +123,9 @@
     "name:kor_x_preferred":[
         "\uc624\uc5d0\ucfe0\uc2dc \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc624\uc5d0\ucfe0\uc2dc\ud604"
+    ],
     "name:lav_x_preferred":[
         "Okussi pa\u0161vald\u012bba"
     ],
@@ -126,8 +135,14 @@
     "name:mar_x_preferred":[
         "\u0913\u0938\u0915\u0947\u0938 \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u041e\u043a\u0443\u0441\u0438"
+    ],
     "name:msa_x_preferred":[
         "Oecusse Municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Oecusse"
     ],
     "name:nld_x_preferred":[
         "Oecusse"
@@ -147,14 +162,23 @@
     "name:por_x_variant":[
         "Distrito Oecussi-Ambeno"
     ],
+    "name:ron_x_preferred":[
+        "Oecusse"
+    ],
     "name:rus_x_preferred":[
         "\u041e\u043a\u0443\u0441\u0438-\u0410\u043c\u0431\u0435\u043d\u043e"
     ],
     "name:sin_x_preferred":[
         "\u0d94\u0d91\u0d9a\u0dd4\u0dc3\u0dda \u0dc3\u0db7\u0dcf\u0dc0"
     ],
+    "name:snd_x_preferred":[
+        "\u0627\u0648\u0626\u064a\u06aa\u0633 \u067e\u0631\u06b3\u06bb\u0648"
+    ],
     "name:spa_x_preferred":[
         "Oecussi-Ambeno"
+    ],
+    "name:srp_x_preferred":[
+        "\u041e\u043a\u0443\u0441\u0438-\u0410\u043c\u0431\u0435\u043d\u043e"
     ],
     "name:swe_x_preferred":[
         "Oecusse"
@@ -313,7 +337,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497442,
+    "wof:lastmodified":1690874633,
     "wof:name":"Ambeno",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/57/85678957.geojson
+++ b/data/856/789/57/85678957.geojson
@@ -105,6 +105,9 @@
     "name:kor_x_preferred":[
         "\uc544\uc77c\ub808\uc6b0 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc544\uc77c\ub808\uc6b0\ud604"
+    ],
     "name:lav_x_preferred":[
         "Aileu pa\u0161vald\u012bba"
     ],
@@ -114,8 +117,14 @@
     "name:mar_x_preferred":[
         "\u0906\u092f\u093f\u0932\u0941 \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0410\u0458\u043b\u0435\u0443"
+    ],
     "name:msa_x_preferred":[
         "Aileu municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Aileu Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Aileu"
@@ -303,7 +312,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497441,
+    "wof:lastmodified":1690874631,
     "wof:name":"Aileu",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/63/85678963.geojson
+++ b/data/856/789/63/85678963.geojson
@@ -41,6 +41,9 @@
     "name:ceb_x_preferred":[
         "Ainaro"
     ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Ainaro"
+    ],
     "name:dan_x_preferred":[
         "Ainaro Municipality"
     ],
@@ -105,6 +108,9 @@
     "name:kor_x_preferred":[
         "\uc544\uc774\ub098\ub8e8 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc544\uc774\ub098\ub8e8\ud604"
+    ],
     "name:lav_x_preferred":[
         "Ainaro pa\u0161vald\u012bba"
     ],
@@ -114,8 +120,14 @@
     "name:mar_x_preferred":[
         "\u0910\u0928\u093e\u0930\u094b \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0410\u0458\u043d\u0430\u0440\u0443"
+    ],
     "name:msa_x_preferred":[
         "Ainaro Municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Ainaro Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Ainaro"
@@ -306,7 +318,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497442,
+    "wof:lastmodified":1690874633,
     "wof:name":"Ainaro",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/67/85678967.geojson
+++ b/data/856/789/67/85678967.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u062f\u064a\u0629 \u0628\u0648\u0643\u0627\u0648"
     ],
+    "name:aze_x_preferred":[
+        "Baukau b\u0259l\u0259diyy\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u0989\u0995\u09be\u0989 \u09aa\u09cc\u09b0\u09b8\u09ad\u09be"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:ceb_x_preferred":[
         "Baucau"
+    ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Baucau"
     ],
     "name:dan_x_preferred":[
         "Baucau Municipality"
@@ -59,6 +65,9 @@
     "name:eng_x_variant":[
         "Baucau District",
         "Baucau Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0628\u0627\u0648\u06a9\u0648"
     ],
     "name:fin_x_preferred":[
         "Baucaun alue"
@@ -105,6 +114,9 @@
     "name:kor_x_preferred":[
         "\ubc14\uc6b0\uce74\uc6b0 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ubc14\uc6b0\uce74\uc6b0\ud604"
+    ],
     "name:lav_x_preferred":[
         "Baukau pa\u0161vald\u012bba"
     ],
@@ -114,8 +126,14 @@
     "name:mar_x_preferred":[
         "\u092c\u0915\u093e\u0909 \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u0430\u0443\u043a\u0430\u0443"
+    ],
     "name:msa_x_preferred":[
         "Baucau Municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Baucau Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Baucau"
@@ -303,7 +321,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497441,
+    "wof:lastmodified":1690874631,
     "wof:name":"Baucau",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/71/85678971.geojson
+++ b/data/856/789/71/85678971.geojson
@@ -41,6 +41,9 @@
     "name:ceb_x_preferred":[
         "Bobonaro"
     ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Bobonaro"
+    ],
     "name:dan_x_preferred":[
         "Bobonaro Municipality"
     ],
@@ -55,6 +58,9 @@
     ],
     "name:eng_x_variant":[
         "Bobonaro Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0628\u0648\u0628\u0648\u0646\u0627\u0631\u0648"
     ],
     "name:fin_x_preferred":[
         "Bobonaron alue"
@@ -98,6 +104,9 @@
     "name:kor_x_preferred":[
         "\ubcf4\ubcf4\ub098\ub8e8 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ubcf4\ubcf4\ub098\ub8e8\ud604"
+    ],
     "name:lav_x_preferred":[
         "Bobonaro pa\u0161vald\u012bba"
     ],
@@ -107,8 +116,14 @@
     "name:mar_x_preferred":[
         "\u092c\u0949\u092c\u094b\u0928\u093e\u0930\u094b \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0411\u043e\u0431\u043e\u043d\u0430\u0440\u0443"
+    ],
     "name:msa_x_preferred":[
         "Bobonaro Municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Bobonaro Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Bobonaro"
@@ -300,7 +315,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497443,
+    "wof:lastmodified":1690874634,
     "wof:name":"Bobonaro",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/75/85678975.geojson
+++ b/data/856/789/75/85678975.geojson
@@ -41,6 +41,9 @@
     "name:ceb_x_preferred":[
         "Cova Lima"
     ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Cova Lima"
+    ],
     "name:dan_x_preferred":[
         "Cova Lima Municipality"
     ],
@@ -56,6 +59,9 @@
     "name:eng_x_variant":[
         "Cova Lima District",
         "Cova Lima Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u06a9\u0648\u0648\u0627 \u0644\u06cc\u0645\u0627"
     ],
     "name:fin_x_preferred":[
         "Cova Liman alue"
@@ -99,6 +105,9 @@
     "name:kor_x_preferred":[
         "\ucf54\ubc14\ub9ac\ub9c8 \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ucf54\ubc14\ub9ac\ub9c8\ud604"
+    ],
     "name:lav_x_preferred":[
         "Kova Lima pa\u0161vald\u012bba"
     ],
@@ -108,8 +117,14 @@
     "name:mar_x_preferred":[
         "\u0915\u0949\u0935\u094d\u0939 \u0932\u093f\u092e\u093e \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u041a\u043e\u0432\u0430 \u041b\u0438\u043c\u0430"
+    ],
     "name:msa_x_preferred":[
         "Cova Lima"
+    ],
+    "name:nan_x_preferred":[
+        "Cova Lima Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Cova Lima"
@@ -297,7 +312,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497442,
+    "wof:lastmodified":1690874632,
     "wof:name":"Cova Lima",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/79/85678979.geojson
+++ b/data/856/789/79/85678979.geojson
@@ -38,6 +38,9 @@
     "name:bul_x_preferred":[
         "\u0415\u0440\u043c\u0435\u0440\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Ermera"
+    ],
     "name:ceb_x_preferred":[
         "Ermera"
     ],
@@ -54,7 +57,11 @@
         "Ermera"
     ],
     "name:eng_x_variant":[
-        "Ermera District"
+        "Ermera District",
+        "Ermera Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0627\u0631\u0645\u0631\u0627"
     ],
     "name:fin_x_preferred":[
         "Ermeran alue"
@@ -98,6 +105,9 @@
     "name:kor_x_preferred":[
         "\uc5d0\ub974\uba54\ub77c \ud604"
     ],
+    "name:kor_x_variant":[
+        "\uc5d0\ub974\uba54\ub77c\ud604"
+    ],
     "name:lav_x_preferred":[
         "Ermeras distrikts"
     ],
@@ -107,8 +117,14 @@
     "name:mar_x_preferred":[
         "\u090f\u0930\u092e\u0947\u0930\u093e \u091c\u093f\u0932\u094d\u0939\u093e"
     ],
+    "name:mkd_x_preferred":[
+        "\u0415\u0440\u043c\u0435\u0440\u0430"
+    ],
     "name:msa_x_preferred":[
         "Ermera District"
+    ],
+    "name:nan_x_preferred":[
+        "Ermera Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Ermera"
@@ -296,7 +312,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497442,
+    "wof:lastmodified":1690874633,
     "wof:name":"Ermera",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/85/85678985.geojson
+++ b/data/856/789/85/85678985.geojson
@@ -54,7 +54,11 @@
         "Manatuto"
     ],
     "name:eng_x_variant":[
-        "Manatuto District"
+        "Manatuto District",
+        "Manatuto Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0645\u0627\u0646\u0627\u062a\u0648\u062a\u0648"
     ],
     "name:fin_x_preferred":[
         "Manatuton alue"
@@ -98,6 +102,9 @@
     "name:kor_x_preferred":[
         "\ub9c8\ub098\ud22c\ud22c \ud604"
     ],
+    "name:kor_x_variant":[
+        "\ub9c8\ub098\ud22c\ud22c\ud604"
+    ],
     "name:lav_x_preferred":[
         "Manatuto distrikts"
     ],
@@ -107,8 +114,14 @@
     "name:mar_x_preferred":[
         "\u092e\u0923\u091f\u0941\u091f\u094b \u091c\u093f\u0932\u094d\u0939\u093e"
     ],
+    "name:mkd_x_preferred":[
+        "\u041c\u0430\u043d\u0430\u0442\u0443\u0442\u0443"
+    ],
     "name:msa_x_preferred":[
         "Manatuto District"
+    ],
+    "name:nan_x_preferred":[
+        "Manatuto Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Manatuto"
@@ -296,7 +309,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497443,
+    "wof:lastmodified":1690874634,
     "wof:name":"Manatuto",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/89/85678989.geojson
+++ b/data/856/789/89/85678989.geojson
@@ -44,6 +44,9 @@
     "name:ceb_x_preferred":[
         "Manufahi"
     ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Manufahi"
+    ],
     "name:dan_x_preferred":[
         "Manufahi Municipality"
     ],
@@ -58,6 +61,9 @@
     ],
     "name:eng_x_variant":[
         "Manufahi Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0645\u0646\u0648\u0641\u0647\u06cc"
     ],
     "name:fin_x_preferred":[
         "Manufahin alue"
@@ -105,7 +111,8 @@
         "\ub9c8\ub204\ud30c\ud788 \uc8fc"
     ],
     "name:kor_x_variant":[
-        "\ub9c8\ub204\ud30c\uc774 \ud604"
+        "\ub9c8\ub204\ud30c\uc774 \ud604",
+        "\ub9c8\ub204\ud30c\uc774\ud604"
     ],
     "name:lav_x_preferred":[
         "Manufahi distrikts"
@@ -116,8 +123,14 @@
     "name:mar_x_preferred":[
         "\u092e\u0928\u0942\u0939\u093e\u0939\u0940 \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u041c\u0430\u043d\u0443\u0444\u0430\u0445\u0438"
+    ],
     "name:msa_x_preferred":[
         "Manufahi Municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Manufahi Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Manufahi"
@@ -305,7 +318,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497442,
+    "wof:lastmodified":1690874632,
     "wof:name":"Manufahi",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/93/85678993.geojson
+++ b/data/856/789/93/85678993.geojson
@@ -32,6 +32,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0644\u062f\u064a\u0629 \u0641\u064a\u0643\u064a\u0643"
     ],
+    "name:aze_x_preferred":[
+        "Vikike b\u0259l\u0259diyy\u0259si"
+    ],
     "name:ben_x_preferred":[
         "\u09ad\u09bf\u0995\u09c1\u09af\u09bc\u09c7\u0995\u09c1\u09af\u09bc\u09c7 \u09aa\u09cc\u09b0\u09b8\u09ad\u09be"
     ],
@@ -40,6 +43,9 @@
     ],
     "name:ceb_x_preferred":[
         "Viqueque"
+    ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Viqueque"
     ],
     "name:dan_x_preferred":[
         "Viqueque Municipality"
@@ -56,6 +62,9 @@
     "name:eng_x_variant":[
         "Viqueque District",
         "Viqueque Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0648\u06cc\u06a9\u06cc\u06a9"
     ],
     "name:fin_x_preferred":[
         "Viquequen alue"
@@ -100,7 +109,8 @@
         "\ube44\ucf00\ucf00 \ud604"
     ],
     "name:kor_x_variant":[
-        "\ube44\ucf00\ud06c \ud604"
+        "\ube44\ucf00\ud06c \ud604",
+        "\ube44\ucf00\ud06c\ud604"
     ],
     "name:lav_x_preferred":[
         "Vikekes pa\u0161vald\u012bba"
@@ -111,8 +121,14 @@
     "name:mar_x_preferred":[
         "\u0935\u093f\u092f\u0941\u0915 \u092e\u094d\u092f\u0941\u0928\u093f\u0938\u093f\u092a\u0932\u093f\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u0412\u0438\u043a\u0435\u043a\u0435"
+    ],
     "name:msa_x_preferred":[
         "Viqueque Municipality"
+    ],
+    "name:nan_x_preferred":[
+        "Viqueque Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Viqueque"
@@ -303,7 +319,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1636497442,
+    "wof:lastmodified":1690874632,
     "wof:name":"Viqueque",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/97/85678997.geojson
+++ b/data/856/789/97/85678997.geojson
@@ -41,6 +41,9 @@
     "name:ceb_x_preferred":[
         "Laut\u00e9m"
     ],
+    "name:cym_x_preferred":[
+        "Bwrdeistref Laut\u00e9m"
+    ],
     "name:dan_x_preferred":[
         "Laut\u00e9m Municipality"
     ],
@@ -58,6 +61,9 @@
         "Laut\u00e9m District",
         "Laut\u00e9m",
         "Laut\u00e9m Municipality"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u062f\u0627\u0631\u06cc \u0644\u0627\u0648\u062a\u0645"
     ],
     "name:fin_x_preferred":[
         "Lautemin alue"
@@ -99,7 +105,8 @@
         "\ub77c\uc6b0\ud15c \ud604"
     ],
     "name:kor_x_variant":[
-        "\ub77c\uc6b0\ud161 \ud604"
+        "\ub77c\uc6b0\ud161 \ud604",
+        "\ub77c\uc6b0\ud161\ud604"
     ],
     "name:lav_x_preferred":[
         "Lautenas pa\u0161vald\u012bba"
@@ -110,8 +117,14 @@
     "name:mar_x_preferred":[
         "\u0932\u094c\u091f\u0947\u092e \u092e\u094d\u092f\u0941\u0928\u094d\u0938\u093f\u092a\u093e\u0932\u094d\u091f\u0940"
     ],
+    "name:mkd_x_preferred":[
+        "\u041b\u0430\u0443\u0442\u0435\u043d"
+    ],
     "name:msa_x_preferred":[
         "Lautem"
+    ],
+    "name:nan_x_preferred":[
+        "Laut\u00e9m Ch\u016b-t\u012b-th\u00e9"
     ],
     "name:nld_x_preferred":[
         "Laut\u00e9m"
@@ -300,7 +313,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1614893748,
+    "wof:lastmodified":1690874633,
     "wof:name":"Lautem",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/890/428/017/890428017.geojson
+++ b/data/890/428/017/890428017.geojson
@@ -21,8 +21,14 @@
     "name:ara_x_preferred":[
         "\u0623\u064a\u0646\u0627\u0631\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u064a\u0646\u0627\u0631\u0648"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0439\u043d\u0430\u0440\u0443"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u0439\u043d\u0430\u0440\u0443"
     ],
     "name:ben_x_preferred":[
         "\u0986\u0987\u09a8\u09be\u09b0\u09c1"
@@ -177,7 +183,7 @@
         }
     ],
     "wof:id":890428017,
-    "wof:lastmodified":1636497446,
+    "wof:lastmodified":1690874637,
     "wof:name":"Ainaro",
     "wof:parent_id":85678963,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.