### PR TITLE
tl concordances, placetype local, and more

### DIFF
--- a/data/856/325/83/85632583.geojson
+++ b/data/856/325/83/85632583.geojson
@@ -1189,6 +1189,7 @@
         "gp:id":23424968,
         "hasc:id":"TL",
         "ioc:id":"TLS",
+        "iso:code":"TL",
         "itu:id":"TLS",
         "m49:code":"626",
         "marc:id":"em",
@@ -1202,6 +1203,7 @@
         "wk:page":"East Timor",
         "wmo:id":"TM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
     "wof:country_alpha3":"TLS",
     "wof:geom_alt":[
@@ -1224,7 +1226,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1694639522,
+    "wof:lastmodified":1695881177,
     "wof:name":"East Timor",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/789/43/85678943.geojson
+++ b/data/856/789/43/85678943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032914,
-    "geom:area_square_m":402575169.95308,
+    "geom:area_square_m":402575321.31219,
     "geom:bbox":"125.489831,-8.627018,125.845993,-8.135024",
     "geom:latitude":-8.438543,
     "geom:longitude":125.62817,
@@ -286,13 +286,15 @@
         "gn:id":1645456,
         "gp:id":24549898,
         "hasc:id":"TL.DL",
+        "iso:code":"TL-DI",
         "iso:id":"TL-DI",
         "qs_pg:id":1062993,
         "wd:id":"Q860901",
         "wk:page":"Dili District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"1283796899e4c8568173c9056e341016",
+    "wof:geomhash":"6eb3f9fe52c689549e42438d866ed350",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -309,7 +311,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874632,
+    "wof:lastmodified":1695884851,
     "wof:name":"Dili",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/51/85678951.geojson
+++ b/data/856/789/51/85678951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044219,
-    "geom:area_square_m":540549958.479231,
+    "geom:area_square_m":540549737.953306,
     "geom:bbox":"125.102942,-8.756209,125.511853,-8.568212",
     "geom:latitude":-8.65808,
     "geom:longitude":125.292354,
@@ -295,14 +295,16 @@
         "gn:id":1637729,
         "gp:id":24549897,
         "hasc:id":"TL.LQ",
+        "iso:code":"TL-LI",
         "iso:id":"TL-LI",
         "qs_pg:id":1062992,
         "unlc:id":"TL-LI",
         "wd:id":"Q860897",
         "wk:page":"Liqui\u00e7\u00e1 District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"fc7dda178a7313cd3e98cd884262674e",
+    "wof:geomhash":"5159a80af1eeba0733d3fbb831b97a21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +321,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874631,
+    "wof:lastmodified":1695884851,
     "wof:name":"Liquica",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/53/85678953.geojson
+++ b/data/856/789/53/85678953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060853,
-    "geom:area_square_m":742512222.342903,
+    "geom:area_square_m":742512478.199764,
     "geom:bbox":"124.03004,-9.501228,124.451504,-9.18019",
     "geom:latitude":-9.327379,
     "geom:longitude":124.266737,
@@ -313,14 +313,16 @@
         "gn:id":1651539,
         "gp:id":24549906,
         "hasc:id":"TL.AM",
+        "iso:code":"TL-OE",
         "iso:id":"TL-OE",
         "qs_pg:id":1018756,
         "unlc:id":"TL-OE",
         "wd:id":"Q860639",
         "wk:page":"Oecusse District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"8c141c170bc3957917f61d7b66cf3c4b",
+    "wof:geomhash":"511735252a64a81ffc04681ed8d93599",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -337,7 +339,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874633,
+    "wof:lastmodified":1695884851,
     "wof:name":"Ambeno",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/57/85678957.geojson
+++ b/data/856/789/57/85678957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063501,
-    "geom:area_square_m":776144421.825117,
+    "geom:area_square_m":776144621.782782,
     "geom:bbox":"125.433615,-8.855635,125.805221,-8.565007",
     "geom:latitude":-8.708243,
     "geom:longitude":125.622187,
@@ -288,14 +288,16 @@
         "gn:id":1651815,
         "gp:id":24549899,
         "hasc:id":"TL.AL",
+        "iso:code":"TL-AL",
         "iso:id":"TL-AL",
         "qs_pg:id":219961,
         "unlc:id":"TL-AL",
         "wd:id":"Q405100",
         "wk:page":"Aileu District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"b3b4f2332cbbc720f68f3c6410919c67",
+    "wof:geomhash":"b2f0b308f778b6c509f7263bdde12354",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -312,7 +314,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874631,
+    "wof:lastmodified":1695884851,
     "wof:name":"Aileu",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/63/85678963.geojson
+++ b/data/856/789/63/85678963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069793,
-    "geom:area_square_m":852355450.797768,
+    "geom:area_square_m":852354583.910198,
     "geom:bbox":"125.410619,-9.2408,125.691377,-8.767992",
     "geom:latitude":-9.008539,
     "geom:longitude":125.554836,
@@ -294,14 +294,16 @@
         "gn:id":1651809,
         "gp:id":24549900,
         "hasc:id":"TL.AN",
+        "iso:code":"TL-AN",
         "iso:id":"TL-AN",
         "qs_pg:id":1287911,
         "unlc:id":"TL-AN",
         "wd:id":"Q405926",
         "wk:page":"Ainaro District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"3280ac6e2aa8c9153ba9a54dd94f35fc",
+    "wof:geomhash":"5ae982d9daa58dd3a8dff16fcb25c28d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -318,7 +320,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874633,
+    "wof:lastmodified":1695884851,
     "wof:name":"Ainaro",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/67/85678967.geojson
+++ b/data/856/789/67/85678967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129013,
-    "geom:area_square_m":1577463376.86301,
+    "geom:area_square_m":1577462012.044901,
     "geom:bbox":"126.140032,-8.706393,126.811722,-8.419122",
     "geom:latitude":-8.570043,
     "geom:longitude":126.464902,
@@ -297,14 +297,16 @@
         "gn:id":1649538,
         "gp:id":24549905,
         "hasc:id":"TL.BC",
+        "iso:code":"TL-BA",
         "iso:id":"TL-BA",
         "qs_pg:id":1062994,
         "unlc:id":"TL-BA",
         "wd:id":"Q811132",
         "wk:page":"Baucau District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"14b75d1d1ec2f340b959aec0a96ba429",
+    "wof:geomhash":"61b927e7f50c8f8edfaa3846f0ad2177",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -321,7 +323,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874631,
+    "wof:lastmodified":1695884851,
     "wof:name":"Baucau",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/71/85678971.geojson
+++ b/data/856/789/71/85678971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117798,
-    "geom:area_square_m":1438744913.616421,
+    "geom:area_square_m":1438745242.683217,
     "geom:bbox":"124.90791,-9.21737,125.4131,-8.740268",
     "geom:latitude":-8.978766,
     "geom:longitude":125.169607,
@@ -290,6 +290,7 @@
         "gn:id":1648513,
         "gp:id":24549896,
         "hasc:id":"TL.BB",
+        "iso:code":"TL-BO",
         "iso:id":"TL-BO",
         "loc:id":"n89219905",
         "qs_pg:id":210215,
@@ -297,8 +298,9 @@
         "wd:id":"Q860913",
         "wk:page":"Bobonaro District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"8964278507f09c7f1407c172c24d6e71",
+    "wof:geomhash":"77a34ca5180c7bf638c81942f2037884",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -315,7 +317,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874634,
+    "wof:lastmodified":1695884852,
     "wof:name":"Bobonaro",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/75/85678975.geojson
+++ b/data/856/789/75/85678975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104066,
-    "geom:area_square_m":1270022163.745434,
+    "geom:area_square_m":1270021808.908375,
     "geom:bbox":"124.954109,-9.485765,125.51113,-9.033815",
     "geom:latitude":-9.262396,
     "geom:longitude":125.220249,
@@ -288,14 +288,16 @@
         "gn:id":1639462,
         "gp:id":24549894,
         "hasc:id":"TL.CL",
+        "iso:code":"TL-CO",
         "iso:id":"TL-CO",
         "qs_pg:id":502859,
         "unlc:id":"TL-CO",
         "wd:id":"Q165575",
         "wk:page":"Cova Lima District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"0c0908cfbb9ce244017e576ba53620bc",
+    "wof:geomhash":"8b5adfd250c11b7015fb0e6fb5d70c49",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -312,7 +314,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874632,
+    "wof:lastmodified":1695884851,
     "wof:name":"Cova Lima",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/79/85678979.geojson
+++ b/data/856/789/79/85678979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058224,
-    "geom:area_square_m":711431784.148234,
+    "geom:area_square_m":711431440.386423,
     "geom:bbox":"125.179212,-8.991441,125.509476,-8.648516",
     "geom:latitude":-8.820358,
     "geom:longitude":125.37162,
@@ -288,14 +288,16 @@
         "gn:id":1644865,
         "gp:id":24549895,
         "hasc:id":"TL.ER",
+        "iso:code":"TL-ER",
         "iso:id":"TL-ER",
         "qs_pg:id":892956,
         "unlc:id":"TL-ER",
         "wd:id":"Q668171",
         "wk:page":"Ermera District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"bb0349000ef43574e209082c9e8503dd",
+    "wof:geomhash":"2343fbe3d8341c6bc95a7ebeaa4625d7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -312,7 +314,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874633,
+    "wof:lastmodified":1695884851,
     "wof:name":"Ermera",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/85/85678985.geojson
+++ b/data/856/789/85/85678985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144486,
-    "geom:area_square_m":1765940932.659779,
+    "geom:area_square_m":1765940959.053399,
     "geom:bbox":"125.757523,-9.057306,126.179203,-8.481134",
     "geom:latitude":-8.718755,
     "geom:longitude":125.96695,
@@ -285,14 +285,16 @@
         "gn:id":1636525,
         "gp:id":24549902,
         "hasc:id":"TL.MT",
+        "iso:code":"TL-MT",
         "iso:id":"TL-MT",
         "qs_pg:id":354742,
         "unlc:id":"TL-MT",
         "wd:id":"Q860630",
         "wk:page":"Manatuto District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"b325d1205b00a172530c8d622600b8b1",
+    "wof:geomhash":"777e2fa9902455c5f6a62a3b37dd6d48",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -309,7 +311,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874634,
+    "wof:lastmodified":1695884852,
     "wof:name":"Manatuto",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/89/85678989.geojson
+++ b/data/856/789/89/85678989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106257,
-    "geom:area_square_m":1297725635.669419,
+    "geom:area_square_m":1297726677.925468,
     "geom:bbox":"125.578929,-9.193272,126.047537,-8.751042",
     "geom:latitude":-8.995662,
     "geom:longitude":125.786669,
@@ -294,14 +294,16 @@
         "gn:id":1636309,
         "gp:id":24549901,
         "hasc:id":"TL.MF",
+        "iso:code":"TL-MF",
         "iso:id":"TL-MF",
         "qs_pg:id":911156,
         "unlc:id":"TL-MF",
         "wd:id":"Q629934",
         "wk:page":"Manufahi District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"f199979b8bee6914d181d8c75c201f54",
+    "wof:geomhash":"5a2def674799c4f01958ef18580488e8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -318,7 +320,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874632,
+    "wof:lastmodified":1695884851,
     "wof:name":"Manufahi",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/93/85678993.geojson
+++ b/data/856/789/93/85678993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155242,
-    "geom:area_square_m":1896965783.885099,
+    "geom:area_square_m":1896966739.760098,
     "geom:bbox":"126.033682,-8.999906,126.738962,-8.607175",
     "geom:latitude":-8.807169,
     "geom:longitude":126.347439,
@@ -295,14 +295,16 @@
         "gn:id":1622470,
         "gp:id":24549903,
         "hasc:id":"TL.VQ",
+        "iso:code":"TL-VI",
         "iso:id":"TL-VI",
         "qs_pg:id":268703,
         "unlc:id":"TL-VI",
         "wd:id":"Q610726",
         "wk:page":"Viqueque District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"a2a4b78f46926f294964484f2a575d1b",
+    "wof:geomhash":"25d301f72466c4f8f27ece6a4318a84c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +321,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874632,
+    "wof:lastmodified":1695884852,
     "wof:name":"Viqueque",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/856/789/97/85678997.geojson
+++ b/data/856/789/97/85678997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15322,
-    "geom:area_square_m":1873720274.369059,
+    "geom:area_square_m":1873720854.688298,
     "geom:bbox":"126.688197,-8.760989,127.313243,-8.309015",
     "geom:latitude":-8.512615,
     "geom:longitude":126.969449,
@@ -289,14 +289,16 @@
         "gn:id":1638294,
         "gp:id":24549904,
         "hasc:id":"TL.BT",
+        "iso:code":"TL-LA",
         "iso:id":"TL-LA",
         "qs_pg:id":354743,
         "unlc:id":"TL-LA",
         "wd:id":"Q686554",
         "wk:page":"Laut\u00e9m District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TL",
-    "wof:geomhash":"e1164b0d17cfcbbb40773c7898afe139",
+    "wof:geomhash":"a181c3e48b706e6c2f2552c53e85b8ba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -313,7 +315,7 @@
         "tet",
         "por"
     ],
-    "wof:lastmodified":1690874633,
+    "wof:lastmodified":1695884504,
     "wof:name":"Lautem",
     "wof:parent_id":85632583,
     "wof:placetype":"region",

--- a/data/890/428/017/890428017.geojson
+++ b/data/890/428/017/890428017.geojson
@@ -189,7 +189,7 @@
         }
     ],
     "wof:id":890428017,
-    "wof:lastmodified":1694498103,
+    "wof:lastmodified":1695886736,
     "wof:name":"Ainaro",
     "wof:parent_id":85678963,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.